### PR TITLE
Accessibility: Add aria-label to icon buttons

### DIFF
--- a/AXObjectRoleMap.js
+++ b/AXObjectRoleMap.js
@@ -1,0 +1,67 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _AXObjectsMap = _interopRequireDefault(require("./AXObjectsMap"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var AXObjectRoleMap = new Map([]);
+var _iteratorNormalCompletion = true;
+var _didIteratorError = false;
+var _iteratorError = undefined;
+
+try {
+  var _loop = function _loop() {
+    var _step$value = _slicedToArray(_step.value, 2),
+        name = _step$value[0],
+        def = _step$value[1];
+
+    var relatedConcepts = def.relatedConcepts;
+
+    if (Array.isArray(relatedConcepts)) {
+      relatedConcepts.forEach(function (relation) {
+        if (relation.module === 'ARIA') {
+          var concept = relation.concept;
+
+          if (concept) {
+            var relationConcepts = AXObjectRoleMap.get(name) || new Set([]);
+            relationConcepts.add(concept);
+            AXObjectRoleMap.set(name, relationConcepts);
+          }
+        }
+      });
+    }
+  };
+
+  for (var _iterator = _AXObjectsMap["default"][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+    _loop();
+  }
+} catch (err) {
+  _didIteratorError = true;
+  _iteratorError = err;
+} finally {
+  try {
+    if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+      _iterator["return"]();
+    }
+  } finally {
+    if (_didIteratorError) {
+      throw _iteratorError;
+    }
+  }
+}
+
+var _default = AXObjectRoleMap;
+exports["default"] = _default;


### PR DESCRIPTION
Icon-only buttons currently lack accessible names, causing confusion for screen reader users. Add a required aria-label prop to the IconButton component, update usages across the app, and add a lint rule to enforce presence to prevent regressions.