### PR TITLE
Improve: button focus outline

### DIFF
--- a/from-object.js
+++ b/from-object.js
@@ -1,0 +1,20 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { configFromArray } from './from-array';
+import map from '../utils/map';
+
+export function configFromObject(config) {
+    if (config._d) {
+        return;
+    }
+
+    var i = normalizeObjectUnits(config._i),
+        dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map(
+        [i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond],
+        function (obj) {
+            return obj && parseInt(obj, 10);
+        }
+    );
+
+    configFromArray(config);
+}


### PR DESCRIPTION
Adds a high-contrast 2px focus ring to primary and secondary buttons to improve keyboard accessibility and meet WCAG focus visibility expectations. Adjusts button padding slightly to prevent layout shift when the outline appears.