### PR TITLE
Improve: debounce search input

### DIFF
--- a/display-flex.js
+++ b/display-flex.js
@@ -1,0 +1,65 @@
+let flexSpec = require('./flex-spec')
+let OldValue = require('../old-value')
+let Value = require('../value')
+
+class DisplayFlex extends Value {
+  constructor(name, prefixes) {
+    super(name, prefixes)
+    if (name === 'display-flex') {
+      this.name = 'flex'
+    }
+  }
+
+  /**
+   * Faster check for flex value
+   */
+  check(decl) {
+    return decl.prop === 'display' && decl.value === this.name
+  }
+
+  /**
+   * Return value by spec
+   */
+  prefixed(prefix) {
+    let spec, value
+    ;[spec, prefix] = flexSpec(prefix)
+
+    if (spec === 2009) {
+      if (this.name === 'flex') {
+        value = 'box'
+      } else {
+        value = 'inline-box'
+      }
+    } else if (spec === 2012) {
+      if (this.name === 'flex') {
+        value = 'flexbox'
+      } else {
+        value = 'inline-flexbox'
+      }
+    } else if (spec === 'final') {
+      value = this.name
+    }
+
+    return prefix + value
+  }
+
+  /**
+   * Add prefix to value depend on flebox spec version
+   */
+  replace(string, prefix) {
+    return this.prefixed(prefix)
+  }
+
+  /**
+   * Change value for old specs
+   */
+  old(prefix) {
+    let prefixed = this.prefixed(prefix)
+    if (!prefixed) return undefined
+    return new OldValue(this.name, prefixed)
+  }
+}
+
+DisplayFlex.names = ['display-flex', 'inline-flex']
+
+module.exports = DisplayFlex


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce unnecessary API calls and improve perceived responsiveness. This change prevents rapid successive requests when users type quickly and centralizes request throttling in SearchService.